### PR TITLE
Fix typo in llvm abstraction

### DIFF
--- a/craftr/lib/compiler.llvm.craftr
+++ b/craftr/lib/compiler.llvm.craftr
@@ -216,7 +216,7 @@ class LlvmCompiler(BaseCompiler):
     elif optimize == 'speed':
       command += ['-O4']
     elif optimize == 'size':
-      commandm += ['-Os']
+      command += ['-Os']
     elif optimize in ('debug', 'none', None):
       command += ['-O0']
     else:


### PR DESCRIPTION
There's a typo in the llvm extension that causes a crash when optimizing for size.